### PR TITLE
Add OCR parsing and CSV export services

### DIFF
--- a/lib/models/parsed_receipt.dart
+++ b/lib/models/parsed_receipt.dart
@@ -1,0 +1,33 @@
+/// Model representing a parsed donation receipt.
+class ParsedReceipt {
+  /// Receipt or reference number if present on the document.
+  final String? receiptNumber;
+
+  /// Date of the donation.
+  final DateTime date;
+
+  /// Name of the donor as printed on the receipt.
+  final String donorName;
+
+  /// Name of the institution issuing the receipt.
+  final String institutionName;
+
+  /// Type of the donation e.g. Zakat or Sadaqah.
+  final String donationType;
+
+  /// Amount donated.
+  final double amount;
+
+  /// Optional free text describing the purpose of the donation.
+  final String? purpose;
+
+  ParsedReceipt({
+    this.receiptNumber,
+    required this.date,
+    required this.donorName,
+    required this.institutionName,
+    required this.donationType,
+    required this.amount,
+    this.purpose,
+  });
+}

--- a/lib/presentation/export_analytics/export_analytics.dart
+++ b/lib/presentation/export_analytics/export_analytics.dart
@@ -2,6 +2,8 @@ import 'package:flutter/material.dart';
 import 'package:sizer/sizer.dart';
 
 import '../../core/app_export.dart';
+import '../../services/export_service.dart';
+import '../../services/receipt_repository.dart';
 import './widgets/analytics_chart_widget.dart';
 import './widgets/export_preview_widget.dart';
 import './widgets/filter_chip_widget.dart';
@@ -26,6 +28,7 @@ class _ExportAnalyticsState extends State<ExportAnalytics>
   RangeValues _amountRange = const RangeValues(0, 10000);
   final List<String> _selectedCategories = [];
   bool _isFilterExpanded = false;
+  final ExportService _exportService = ExportService();
 
   // Mock data
   final List<Map<String, dynamic>> _mockDonationData = [
@@ -538,6 +541,36 @@ class _ExportAnalyticsState extends State<ExportAnalytics>
             ),
           ),
         ),
+        SizedBox(height: 2.h),
+        SizedBox(
+          width: double.infinity,
+          child: ElevatedButton.icon(
+            onPressed: _isExporting ? null : _downloadCsv,
+            icon: _isExporting
+                ? SizedBox(
+                    width: 20,
+                    height: 20,
+                    child: CircularProgressIndicator(
+                      strokeWidth: 2,
+                      valueColor: AlwaysStoppedAnimation<Color>(Colors.white),
+                    ),
+                  )
+                : CustomIconWidget(
+                    iconName: 'file_download',
+                    color: Colors.white,
+                    size: 20,
+                  ),
+            label: const Text('Download Donations'),
+            style: ElevatedButton.styleFrom(
+              backgroundColor: const Color(0xFF2E7D32),
+              foregroundColor: Colors.white,
+              padding: EdgeInsets.symmetric(vertical: 2.h),
+              textStyle: AppTheme.lightTheme.textTheme.titleMedium?.copyWith(
+                fontWeight: FontWeight.w600,
+              ),
+            ),
+          ),
+        ),
       ],
     );
   }
@@ -681,6 +714,25 @@ class _ExportAnalyticsState extends State<ExportAnalytics>
           ),
         ),
       );
+    }
+  }
+
+  void _downloadCsv() async {
+    setState(() => _isExporting = true);
+    try {
+      final file = await _exportService
+          .exportReceiptsToCsv(ReceiptRepository.instance.receipts);
+      if (!mounted) return;
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(
+          content: Text('CSV saved to ${file.path}'),
+          backgroundColor: const Color(0xFF2E7D32),
+        ),
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _isExporting = false);
+      }
     }
   }
 }

--- a/lib/presentation/ocr_camera_scan/ocr_camera_scan.dart
+++ b/lib/presentation/ocr_camera_scan/ocr_camera_scan.dart
@@ -3,6 +3,9 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 
 import '../../core/app_export.dart';
+import '../../services/ocr_service.dart';
+import '../../services/receipt_parser.dart';
+import '../../services/receipt_repository.dart';
 import './widgets/camera_overlay_widget.dart';
 import './widgets/capture_controls_widget.dart';
 import './widgets/ocr_results_bottom_sheet.dart';
@@ -27,16 +30,9 @@ class _OcrCameraScanState extends State<OcrCameraScan>
   XFile? _lastCapturedImage;
   late AnimationController _pulseAnimationController;
   late Animation<double> _pulseAnimation;
+  final OcrService _ocrService = OcrService();
 
-  // Mock OCR results
-  final Map<String, dynamic> _mockOcrResults = {
-    "donorName": "Ahmed Al-Rashid",
-    "amount": "500.00",
-    "currency": "SAR",
-    "date": "2024-01-15",
-    "category": "Zakat",
-    "notes": "Monthly donation for mosque maintenance"
-  };
+  ParsedReceipt? _lastParsedReceipt;
 
   @override
   void initState() {
@@ -121,14 +117,16 @@ class _OcrCameraScanState extends State<OcrCameraScan>
           _isProcessing = true;
         });
 
-        // Simulate OCR processing
-        await Future.delayed(const Duration(seconds: 3));
+        final rawText = await _ocrService.extractRawText(image);
+        final parsed = ReceiptParser.parseReceipt(rawText);
+        ReceiptRepository.instance.add(parsed);
 
         if (mounted) {
           setState(() {
             _isProcessing = false;
+            _lastParsedReceipt = parsed;
           });
-          _showOcrResults();
+          _showOcrResults(parsed);
         }
       } catch (e) {
         debugPrint('Error capturing image: $e');
@@ -139,13 +137,20 @@ class _OcrCameraScanState extends State<OcrCameraScan>
     }
   }
 
-  void _showOcrResults() {
+  void _showOcrResults(ParsedReceipt parsed) {
     showModalBottomSheet(
       context: context,
       isScrollControlled: true,
       backgroundColor: Colors.transparent,
       builder: (context) => OcrResultsBottomSheet(
-        ocrResults: _mockOcrResults,
+        ocrResults: {
+          'donorName': parsed.donorName,
+          'amount': parsed.amount.toStringAsFixed(2),
+          'currency': 'USD',
+          'date': parsed.date.toIso8601String(),
+          'category': parsed.donationType,
+          'notes': parsed.purpose ?? ''
+        },
         capturedImage: _capturedImage,
         onSave: _saveDonationRecord,
         onRetake: _retakeImage,
@@ -196,6 +201,7 @@ class _OcrCameraScanState extends State<OcrCameraScan>
   void dispose() {
     _cameraController?.dispose();
     _pulseAnimationController.dispose();
+    _ocrService.dispose();
     super.dispose();
   }
 

--- a/lib/services/export_service.dart
+++ b/lib/services/export_service.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+
+import 'package:csv/csv.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:excel/excel.dart';
+
+import '../models/parsed_receipt.dart';
+
+/// Service responsible for exporting receipts to files.
+class ExportService {
+  /// Export [receipts] to a CSV file located in the user's documents directory.
+  Future<File> exportReceiptsToCsv(List<ParsedReceipt> receipts) async {
+    final rows = <List<dynamic>>[];
+    rows.add([
+      'Receipt Number',
+      'Date',
+      'Donor Name',
+      'Institution',
+      'Donation Type',
+      'Amount',
+      'Purpose'
+    ]);
+
+    for (final r in receipts) {
+      rows.add([
+        r.receiptNumber ?? '',
+        r.date.toIso8601String(),
+        r.donorName,
+        r.institutionName,
+        r.donationType,
+        r.amount,
+        r.purpose ?? ''
+      ]);
+    }
+
+    final csvData = const ListToCsvConverter().convert(rows);
+    final directory = await getApplicationDocumentsDirectory();
+    final file =
+        File('${directory.path}/donations_${DateTime.now().millisecondsSinceEpoch}.csv');
+    await file.writeAsString(csvData);
+    return file;
+  }
+
+  /// Export [receipts] to an Excel file located in the user's documents directory.
+  Future<File> exportReceiptsToExcel(List<ParsedReceipt> receipts) async {
+    final excel = Excel.createExcel();
+    final sheet = excel['Receipts'];
+    sheet.appendRow([
+      'Receipt Number',
+      'Date',
+      'Donor Name',
+      'Institution',
+      'Donation Type',
+      'Amount',
+      'Purpose'
+    ]);
+
+    for (final r in receipts) {
+      sheet.appendRow([
+        r.receiptNumber ?? '',
+        r.date.toIso8601String(),
+        r.donorName,
+        r.institutionName,
+        r.donationType,
+        r.amount,
+        r.purpose ?? ''
+      ]);
+    }
+
+    final directory = await getApplicationDocumentsDirectory();
+    final file =
+        File('${directory.path}/donations_${DateTime.now().millisecondsSinceEpoch}.xlsx');
+    await file.writeAsBytes(excel.encode()!);
+    return file;
+  }
+}

--- a/lib/services/ocr_service.dart
+++ b/lib/services/ocr_service.dart
@@ -1,0 +1,20 @@
+import 'package:camera/camera.dart';
+import 'package:google_ml_kit/google_ml_kit.dart';
+
+/// Service handling OCR text extraction using Google ML Kit.
+class OcrService {
+  final TextRecognizer _textRecognizer = GoogleMlKit.vision.textRecognizer();
+
+  /// Extracts raw text from the given [imageFile].
+  Future<String> extractRawText(XFile imageFile) async {
+    final inputImage = InputImage.fromFilePath(imageFile.path);
+    final RecognizedText recognisedText =
+        await _textRecognizer.processImage(inputImage);
+    return recognisedText.text;
+  }
+
+  /// Dispose the underlying text recognizer.
+  void dispose() {
+    _textRecognizer.close();
+  }
+}

--- a/lib/services/receipt_parser.dart
+++ b/lib/services/receipt_parser.dart
@@ -1,0 +1,103 @@
+import '../models/parsed_receipt.dart';
+
+/// Utility responsible for parsing text extracted from donation receipts.
+class ReceiptParser {
+  /// Parse [rawText] from an OCR operation into a [ParsedReceipt].
+  static ParsedReceipt parseReceipt(String rawText) {
+    final lines = rawText.split(RegExp(r'\r?\n'));
+    final lowerText = rawText.toLowerCase();
+
+    final receiptNumber = _extractReceiptNumber(rawText);
+    final date = _extractDate(rawText) ?? DateTime.now();
+    final donorName = _extractFirstMatch(lines,
+            RegExp(r'(?:donor|name|given by)[:\-]\s*(.+)', caseSensitive: false)) ??
+        '';
+    final institutionName = _extractInstitutionName(lines);
+    final donationType = _extractDonationType(lowerText);
+    final amount = _extractAmount(rawText) ?? 0.0;
+    final purpose = _extractFirstMatch(lines,
+        RegExp(r'(?:for|purpose|notes?)[:\-]\s*(.+)', caseSensitive: false));
+
+    return ParsedReceipt(
+      receiptNumber: receiptNumber,
+      date: date,
+      donorName: donorName,
+      institutionName: institutionName,
+      donationType: donationType,
+      amount: amount,
+      purpose: purpose,
+    );
+  }
+
+  static String? _extractReceiptNumber(String text) {
+    final match = RegExp(r'(?:Receipt\s*[#:]\s*|Ref[: ]?)(\w+)')
+        .firstMatch(text);
+    return match?.group(1);
+  }
+
+  static DateTime? _extractDate(String text) {
+    final patterns = [
+      RegExp(r'(\d{1,2}[\/\-]\d{1,2}[\/\-]\d{2,4})'),
+      RegExp(
+          r'(January|February|March|April|May|June|July|August|September|October|November|December)\s+\d{1,2},?\s+\d{4}',
+          caseSensitive: false),
+    ];
+    for (final pattern in patterns) {
+      final match = pattern.firstMatch(text);
+      if (match != null) {
+        final raw = match.group(0)!;
+        final parsed = DateTime.tryParse(raw);
+        if (parsed != null) return parsed;
+        // Fallback for MM/DD/YYYY
+        final alt = raw.replaceAll(RegExp(r'[^0-9/]'), '');
+        final parts = alt.split('/');
+        if (parts.length == 3) {
+          final month = int.tryParse(parts[0]);
+          final day = int.tryParse(parts[1]);
+          final year = int.tryParse(parts[2]);
+          if (month != null && day != null && year != null) {
+            return DateTime(year, month, day);
+          }
+        }
+      }
+    }
+    return null;
+  }
+
+  static String _extractInstitutionName(List<String> lines) {
+    for (final line in lines.take(5)) {
+      if (line.toLowerCase().contains('masjid') ||
+          line.toLowerCase().contains('mosque') ||
+          line.toLowerCase().contains('islamic center')) {
+        return line.trim();
+      }
+    }
+    return '';
+  }
+
+  static String _extractDonationType(String lowerText) {
+    if (lowerText.contains('zakat')) return 'Zakat';
+    if (lowerText.contains('sadaqah')) return 'Sadaqah';
+    if (lowerText.contains('donation')) return 'General Donation';
+    return '';
+  }
+
+  static double? _extractAmount(String text) {
+    final match = RegExp(r'(?:Amount|Paid|Total)[: ]*\$?([\d,]+\.\d{2})')
+        .firstMatch(text);
+    if (match != null) {
+      return double.tryParse(match.group(1)!.replaceAll(',', ''));
+    }
+    return null;
+  }
+
+  static String? _extractFirstMatch(List<String> lines, RegExp regExp) {
+    for (final line in lines) {
+      final match = regExp.firstMatch(line);
+      if (match != null) {
+        return match.group(1)?.trim();
+      }
+    }
+    return null;
+  }
+}

--- a/lib/services/receipt_repository.dart
+++ b/lib/services/receipt_repository.dart
@@ -1,0 +1,18 @@
+import '../models/parsed_receipt.dart';
+
+/// Simple in-memory repository for parsed receipts.
+class ReceiptRepository {
+  ReceiptRepository._();
+
+  static final ReceiptRepository instance = ReceiptRepository._();
+
+  final List<ParsedReceipt> _receipts = [];
+
+  List<ParsedReceipt> get receipts => List.unmodifiable(_receipts);
+
+  void add(ParsedReceipt receipt) {
+    _receipts.add(receipt);
+  }
+
+  void clear() => _receipts.clear();
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,10 @@ dependencies:
   flutter_dotenv: ^5.2.1
   camera: ^0.10.5+5
   image_picker: ^1.0.4
+  google_ml_kit: ^0.16.3
+  path_provider: ^2.1.2
+  csv: ^5.0.1
+  excel: ^2.0.0
   web: any
 dev_dependencies: 
   flutter_test: 


### PR DESCRIPTION
## Summary
- add Google ML Kit, path provider, csv and excel packages
- create `ParsedReceipt` model
- implement OCR and receipt parsing services
- allow exporting receipts to CSV and Excel
- wire OCR parsing into camera capture
- add download button in Export Analytics screen

## Testing
- `dart analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68500eabef5c832bab058098f2074672