### PR TITLE
Add settings page navigation

### DIFF
--- a/lib/presentation/dashboard_home/dashboard_home.dart
+++ b/lib/presentation/dashboard_home/dashboard_home.dart
@@ -148,7 +148,7 @@ class _DashboardHomeState extends State<DashboardHome>
         Navigator.pushNamed(context, '/export-analytics');
         break;
       case 4:
-        // Settings - placeholder
+        Navigator.pushNamed(context, '/settings-profile');
         break;
     }
   }


### PR DESCRIPTION
## Summary
- link Dashboard navigation to the settings profile screen

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501c302dd8832bacc320663bc089bb