### PR TITLE
Add Supabase auth service

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,13 @@ Container(
   child: Text('Responsive Container'),
 )
 ```
+
+## 🔐 Authentication
+
+The project uses [Supabase](https://supabase.com) for user authentication.
+Before running the app, set `SUPABASE_URL` and `SUPABASE_ANON_KEY` in the `.env`
+file. Use `AuthService` to sign up, sign in, and sign out users via Supabase.
+
 ## 📦 Deployment
 
 Build the application for production:

--- a/lib/core/app_export.dart
+++ b/lib/core/app_export.dart
@@ -3,3 +3,4 @@ export 'package:flutter_template/routes/app_routes.dart';
 export 'package:flutter_template/widgets/custom_icon_widget.dart';
 export 'package:flutter_template/widgets/custom_image_widget.dart';
 export 'package:flutter_template/theme/app_theme.dart';
+export 'package:flutter_template/core/services/auth_service.dart';

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -1,0 +1,33 @@
+import 'package:supabase_flutter/supabase_flutter.dart';
+
+/// Service responsible for authenticating users using Supabase.
+class AuthService {
+  final SupabaseClient _client = Supabase.instance.client;
+
+  /// Creates a new user using [email] and [password].
+  Future<AuthResponse> signUp({
+    required String email,
+    required String password,
+  }) async {
+    return await _client.auth.signUp(
+      email: email,
+      password: password,
+    );
+  }
+
+  /// Logs in a user using [email] and [password].
+  Future<AuthResponse> signIn({
+    required String email,
+    required String password,
+  }) async {
+    return await _client.auth.signInWithPassword(
+      email: email,
+      password: password,
+    );
+  }
+
+  /// Signs out the currently authenticated user.
+  Future<void> signOut() async {
+    await _client.auth.signOut();
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_dotenv/flutter_dotenv.dart';
 import 'package:sizer/sizer.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
 
 import '../widgets/custom_error_widget.dart';
 import 'core/app_export.dart';
@@ -9,6 +10,10 @@ import 'core/app_export.dart';
 void main() async {
   await dotenv.load();
   WidgetsFlutterBinding.ensureInitialized();
+  await Supabase.initialize(
+    url: dotenv.env['SUPABASE_URL']!,
+    anonKey: dotenv.env['SUPABASE_ANON_KEY']!,
+  );
   ErrorWidget.builder = (FlutterErrorDetails details) {
     return CustomErrorWidget(
       errorDetails: details,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,7 @@ dependencies:
   flutter_dotenv: ^5.2.1
   camera: ^0.10.5+5
   image_picker: ^1.0.4
+  supabase_flutter: ^2.3.4
   web: any
 dev_dependencies: 
   flutter_test: 


### PR DESCRIPTION
## Summary
- add `supabase_flutter` dependency
- initialize Supabase in `main.dart`
- expose a new `AuthService` for sign up, sign in and sign out
- export `AuthService` via `app_export.dart`
- document authentication in the README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68503e0e629c832bb20c77ee7140a2f3