### PR TITLE
Add login flow and rename app

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET"/>
 
     <application
-            android:label="flutter_template"
+            android:label="Noor Funds"
             android:name="${applicationName}"
             android:icon="@mipmap/ic_launcher">
         <activity

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
-    <string name="app_name">flutter_template</string>
+    <string name="app_name">Noor Funds</string>
 
 </resources>

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -10,8 +10,8 @@
 	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
-	<key>CFBundleName</key>
-	<string>flutter_template</string>
+        <key>CFBundleName</key>
+        <string>Noor Funds</string>
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>

--- a/lib/core/app_export.dart
+++ b/lib/core/app_export.dart
@@ -1,5 +1,5 @@
 export 'package:connectivity_plus/connectivity_plus.dart';
-export 'package:flutter_template/routes/app_routes.dart';
-export 'package:flutter_template/widgets/custom_icon_widget.dart';
-export 'package:flutter_template/widgets/custom_image_widget.dart';
-export 'package:flutter_template/theme/app_theme.dart';
+export 'package:noor_funds/routes/app_routes.dart';
+export 'package:noor_funds/widgets/custom_icon_widget.dart';
+export 'package:noor_funds/widgets/custom_image_widget.dart';
+export 'package:noor_funds/theme/app_theme.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -28,7 +28,7 @@ class MyApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return Sizer(builder: (context, orientation, screenType) {
       return MaterialApp(
-        title: 'flutter_template',
+        title: 'Noor Funds',
         theme: AppTheme.lightTheme,
         darkTheme: AppTheme.darkTheme,
         themeMode: ThemeMode.light,

--- a/lib/presentation/auth/login_screen.dart
+++ b/lib/presentation/auth/login_screen.dart
@@ -1,0 +1,76 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../core/app_export.dart';
+
+class LoginScreen extends StatefulWidget {
+  const LoginScreen({super.key});
+
+  @override
+  State<LoginScreen> createState() => _LoginScreenState();
+}
+
+class _LoginScreenState extends State<LoginScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    super.dispose();
+  }
+
+  void _login() {
+    Navigator.pushReplacementNamed(context, '/dashboard-home');
+  }
+
+  void _goToSignUp() {
+    Navigator.pushReplacementNamed(context, '/sign-up');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'Login',
+          style: GoogleFonts.inter(fontWeight: FontWeight.bold),
+        ),
+        backgroundColor: const Color(0xFF2E7D32),
+        foregroundColor: Colors.white,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _passwordController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: 'Password'),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _login,
+                child: const Text('Login'),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: _goToSignUp,
+              child: const Text("Don't have an account? Sign Up"),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/auth/sign_up_screen.dart
+++ b/lib/presentation/auth/sign_up_screen.dart
@@ -1,0 +1,84 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+import '../../core/app_export.dart';
+
+class SignUpScreen extends StatefulWidget {
+  const SignUpScreen({super.key});
+
+  @override
+  State<SignUpScreen> createState() => _SignUpScreenState();
+}
+
+class _SignUpScreenState extends State<SignUpScreen> {
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _passwordController = TextEditingController();
+  final TextEditingController _confirmController = TextEditingController();
+
+  @override
+  void dispose() {
+    _emailController.dispose();
+    _passwordController.dispose();
+    _confirmController.dispose();
+    super.dispose();
+  }
+
+  void _signUp() {
+    Navigator.pushReplacementNamed(context, '/dashboard-home');
+  }
+
+  void _goToLogin() {
+    Navigator.pushReplacementNamed(context, '/login');
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: Text(
+          'Sign Up',
+          style: GoogleFonts.inter(fontWeight: FontWeight.bold),
+        ),
+        backgroundColor: const Color(0xFF2E7D32),
+        foregroundColor: Colors.white,
+      ),
+      body: Padding(
+        padding: const EdgeInsets.all(24.0),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            TextField(
+              controller: _emailController,
+              decoration: const InputDecoration(labelText: 'Email'),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _passwordController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: 'Password'),
+            ),
+            const SizedBox(height: 16),
+            TextField(
+              controller: _confirmController,
+              obscureText: true,
+              decoration: const InputDecoration(labelText: 'Confirm Password'),
+            ),
+            const SizedBox(height: 24),
+            SizedBox(
+              width: double.infinity,
+              child: ElevatedButton(
+                onPressed: _signUp,
+                child: const Text('Sign Up'),
+              ),
+            ),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: _goToLogin,
+              child: const Text('Already have an account? Login'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/presentation/dashboard_home/dashboard_home.dart
+++ b/lib/presentation/dashboard_home/dashboard_home.dart
@@ -325,7 +325,7 @@ class _DashboardHomeState extends State<DashboardHome>
             children: [
               Expanded(
                 child: Text(
-                  'السلام عليكم\nWelcome to DonationScan',
+                  'السلام عليكم\nWelcome to Noor Funds',
                   style: AppTheme.lightTheme.textTheme.titleLarge?.copyWith(
                     color: Colors.white,
                     fontWeight: FontWeight.bold,

--- a/lib/presentation/onboarding_flow/onboarding_flow.dart
+++ b/lib/presentation/onboarding_flow/onboarding_flow.dart
@@ -16,7 +16,7 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
 
   final List<Map<String, dynamic>> _onboardingData = [
     {
-      'title': 'Welcome to DonationScan',
+      'title': 'Welcome to Noor Funds',
       'description':
           'Your complete Islamic donation management solution for organizing and tracking all charitable contributions with ease.',
       'icon': 'mosque',
@@ -85,12 +85,12 @@ class _OnboardingFlowState extends State<OnboardingFlow> {
     // using a package like permission_handler
 
     // After permissions are granted, navigate to the dashboard
-    Navigator.pushReplacementNamed(context, '/dashboard-home');
+    Navigator.pushReplacementNamed(context, '/login');
 
     // Show a welcome toast
     ScaffoldMessenger.of(context).showSnackBar(
       SnackBar(
-        content: Text('Welcome to DonationScan!'),
+        content: Text('Welcome to Noor Funds!'),
         duration: Duration(seconds: 2),
         backgroundColor: Color(0xFF2E7D32),
       ),

--- a/lib/presentation/settings_profile/settings_profile.dart
+++ b/lib/presentation/settings_profile/settings_profile.dart
@@ -188,7 +188,7 @@ class _SettingsProfileState extends State<SettingsProfile> {
     showDialog(
       context: context,
       builder: (context) => AlertDialog(
-        title: Text('About DonationScan'),
+        title: Text('About Noor Funds'),
         content: Column(
           mainAxisSize: MainAxisSize.min,
           children: [
@@ -199,7 +199,7 @@ class _SettingsProfileState extends State<SettingsProfile> {
             ),
             SizedBox(height: 16),
             Text(
-              'DonationScan',
+              'Noor Funds',
               style: GoogleFonts.inter(
                 fontSize: 18,
                 fontWeight: FontWeight.bold,
@@ -215,7 +215,7 @@ class _SettingsProfileState extends State<SettingsProfile> {
             ),
             SizedBox(height: 16),
             Text(
-              '© 2023 DonationScan',
+              '© 2023 Noor Funds',
               style: GoogleFonts.inter(
                 fontSize: 12,
                 color: Colors.grey,
@@ -356,7 +356,7 @@ class _SettingsProfileState extends State<SettingsProfile> {
               children: [
                 SettingsOptionItemWidget(
                   title: 'App Version',
-                  subtitle: 'DonationScan v1.0.0',
+                  subtitle: 'Noor Funds v1.0.0',
                   onTap: _showAboutDialog,
                   leadingIcon: 'info',
                 ),

--- a/lib/presentation/splash_screen/splash_screen.dart
+++ b/lib/presentation/splash_screen/splash_screen.dart
@@ -57,12 +57,14 @@ class _SplashScreenState extends State<SplashScreen>
     // or making API calls to validate user session
     Timer(const Duration(milliseconds: 2500), () {
       bool isFirstTimeUser = true; // This would be determined from storage
+      bool isLoggedIn = false; // Replace with real auth check
 
-      // Navigate to appropriate screen based on user status
       if (isFirstTimeUser) {
         Navigator.pushReplacementNamed(context, '/onboarding-flow');
-      } else {
+      } else if (isLoggedIn) {
         Navigator.pushReplacementNamed(context, '/dashboard-home');
+      } else {
+        Navigator.pushReplacementNamed(context, '/login');
       }
     });
   }
@@ -124,7 +126,7 @@ class _SplashScreenState extends State<SplashScreen>
 
               // App name in Arabic style
               Text(
-                'DonationScan',
+                'Noor Funds',
                 style: GoogleFonts.inter(
                   fontSize: 32,
                   fontWeight: FontWeight.bold,

--- a/lib/routes/app_routes.dart
+++ b/lib/routes/app_routes.dart
@@ -8,11 +8,15 @@ import '../presentation/export_analytics/export_analytics.dart';
 import '../presentation/splash_screen/splash_screen.dart';
 import '../presentation/onboarding_flow/onboarding_flow.dart';
 import '../presentation/settings_profile/settings_profile.dart';
+import '../presentation/auth/login_screen.dart';
+import '../presentation/auth/sign_up_screen.dart';
 
 class AppRoutes {
   static const String initial = '/splash-screen';
   static const String splashScreen = '/splash-screen';
   static const String onboardingFlow = '/onboarding-flow';
+  static const String login = '/login';
+  static const String signUp = '/sign-up';
   static const String dashboardHome = '/dashboard-home';
   static const String ocrCameraScan = '/ocr-camera-scan';
   static const String ocrResultsVerification = '/ocr-results-verification';
@@ -25,6 +29,8 @@ class AppRoutes {
     initial: (context) => const SplashScreen(),
     splashScreen: (context) => const SplashScreen(),
     onboardingFlow: (context) => const OnboardingFlow(),
+    login: (context) => const LoginScreen(),
+    signUp: (context) => const SignUpScreen(),
     dashboardHome: (context) => const DashboardHome(),
     ocrCameraScan: (context) => const OcrCameraScan(),
     ocrResultsVerification: (context) => const OcrResultsVerification(),

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,4 +1,4 @@
-name: flutter_template
+name: noor_funds
 description: A new Flutter project.
 version: 1.0.0+1
 environment: 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -8,7 +8,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import 'package:flutter_template/main.dart';
+import 'package:noor_funds/main.dart';
 
 void main() {
   testWidgets('Counter increments smoke test', (WidgetTester tester) async {


### PR DESCRIPTION
## Summary
- add login & sign up pages
- route to login after onboarding and on splash screen
- rename DonationScan to Noor Funds throughout the UI
- update Android/iOS config to reflect new app name
- expose new routes

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68501d36b81c832b92591033ac4e986f