### PR TITLE
Fix color alpha helper

### DIFF
--- a/lib/core/app_export.dart
+++ b/lib/core/app_export.dart
@@ -3,3 +3,4 @@ export 'package:flutter_template/routes/app_routes.dart';
 export 'package:flutter_template/widgets/custom_icon_widget.dart';
 export 'package:flutter_template/widgets/custom_image_widget.dart';
 export 'package:flutter_template/theme/app_theme.dart';
+export 'package:flutter_template/core/extensions/color_extensions.dart';

--- a/lib/core/extensions/color_extensions.dart
+++ b/lib/core/extensions/color_extensions.dart
@@ -1,0 +1,15 @@
+import 'package:flutter/material.dart';
+
+extension ColorOpacityExtension on Color {
+  /// Returns a copy of this color with the given opacity [alpha] value.
+  ///
+  /// The [alpha] is expected to be between 0.0 and 1.0. If `alpha` is null,
+  /// the original color is returned unchanged.
+  Color withValues({double? alpha}) {
+    if (alpha == null) {
+      return this;
+    }
+    final double opacity = alpha.clamp(0.0, 1.0);
+    return withOpacity(opacity);
+  }
+}

--- a/lib/theme/app_theme.dart
+++ b/lib/theme/app_theme.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
 
+import '../core/extensions/color_extensions.dart';
+
 /// A class that contains all theme configurations for the application.
 class AppTheme {
   AppTheme._();


### PR DESCRIPTION
## Summary
- add a color extension to support `withValues` calls
- export the extension via `app_export.dart`
- use the extension in theme

## Testing
- `flutter test` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684df8a34308832ba4ea6707c1b293f9