### PR TITLE
Add local local storage and Hive DB

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,18 @@ Container(
   child: Text('Responsive Container'),
 )
 ```
+
+## 🔐 Local Storage
+
+Scanned images are stored on the device using `path_provider`. Files are placed
+in the application's documents directory under `scans/` to keep sensitive data
+offline.
+
+## 🗄️ Local Database
+
+Authentication details and donation records are persisted locally with Hive.
+Hive boxes are initialized in `main.dart` and accessed through
+`DatabaseService` and `AuthService`.
 ## 📦 Deployment
 
 Build the application for production:

--- a/lib/core/app_export.dart
+++ b/lib/core/app_export.dart
@@ -3,3 +3,6 @@ export 'package:flutter_template/routes/app_routes.dart';
 export 'package:flutter_template/widgets/custom_icon_widget.dart';
 export 'package:flutter_template/widgets/custom_image_widget.dart';
 export 'package:flutter_template/theme/app_theme.dart';
+export 'package:flutter_template/core/services/local_storage_service.dart';
+export 'package:flutter_template/core/services/database_service.dart';
+export 'package:flutter_template/core/services/auth_service.dart';

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -1,0 +1,21 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import 'database_service.dart';
+
+class AuthService {
+  static const _keyEmail = 'email';
+  static const _keyPassword = 'password';
+
+  static Future<void> saveCredentials(String email, String password) async {
+    final box = DatabaseService.authBox;
+    await box.put(_keyEmail, email);
+    await box.put(_keyPassword, password);
+  }
+
+  static Map<String, String?> getCredentials() {
+    final box = DatabaseService.authBox;
+    return {
+      'email': box.get(_keyEmail) as String?,
+      'password': box.get(_keyPassword) as String?,
+    };
+  }
+}

--- a/lib/core/services/database_service.dart
+++ b/lib/core/services/database_service.dart
@@ -1,0 +1,12 @@
+import 'package:hive_flutter/hive_flutter.dart';
+
+class DatabaseService {
+  static Future<void> init() async {
+    await Hive.initFlutter();
+    await Hive.openBox('auth');
+    await Hive.openBox('donations');
+  }
+
+  static Box get authBox => Hive.box('auth');
+  static Box get donationsBox => Hive.box('donations');
+}

--- a/lib/core/services/local_storage_service.dart
+++ b/lib/core/services/local_storage_service.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+import 'package:path_provider/path_provider.dart';
+
+class LocalStorageService {
+  /// Saves [image] to a secure application directory.
+  ///
+  /// Returns the file path where the image was stored.
+  static Future<String> saveImage(File image) async {
+    final directory = await getApplicationDocumentsDirectory();
+    final scansDir = Directory('${directory.path}/scans');
+    if (!await scansDir.exists()) {
+      await scansDir.create(recursive: true);
+    }
+    final fileName = DateTime.now().millisecondsSinceEpoch.toString();
+    final extension = image.path.split('.').last;
+    final storedImage = await image.copy('${scansDir.path}/$fileName.$extension');
+    return storedImage.path;
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'core/app_export.dart';
 void main() async {
   await dotenv.load();
   WidgetsFlutterBinding.ensureInitialized();
+  await DatabaseService.init();
   ErrorWidget.builder = (FlutterErrorDetails details) {
     return CustomErrorWidget(
       errorDetails: details,

--- a/lib/presentation/ocr_camera_scan/ocr_camera_scan.dart
+++ b/lib/presentation/ocr_camera_scan/ocr_camera_scan.dart
@@ -1,6 +1,7 @@
 import 'package:camera/camera.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'dart:io';
 
 import '../../core/app_export.dart';
 import './widgets/camera_overlay_widget.dart';
@@ -153,8 +154,12 @@ class _OcrCameraScanState extends State<OcrCameraScan>
     );
   }
 
-  void _saveDonationRecord(Map<String, dynamic> donationData) {
-    // Mock save functionality
+  Future<void> _saveDonationRecord(Map<String, dynamic> donationData) async {
+    if (_capturedImage != null) {
+      final path = await LocalStorageService.saveImage(File(_capturedImage!.path));
+      donationData['imagePath'] = path;
+    }
+    await DatabaseService.donationsBox.add(donationData);
     Navigator.of(context).pop(); // Close bottom sheet
     Navigator.of(context).pop(); // Return to previous screen
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,12 +18,17 @@ dependencies:
   flutter_dotenv: ^5.2.1
   camera: ^0.10.5+5
   image_picker: ^1.0.4
+  hive: ^2.2.3
+  hive_flutter: ^1.1.0
+  path_provider: ^2.1.2
   web: any
-dev_dependencies: 
-  flutter_test: 
+dev_dependencies:
+  flutter_test:
     sdk: flutter
   flutter_lints: ^5.0.0
-flutter: 
+  hive_generator: ^2.0.1
+  build_runner: ^2.4.7
+flutter:
   uses-material-design: true
   assets: 
     - assets/


### PR DESCRIPTION
## Summary
- store captured scan images locally using `LocalStorageService`
- add Hive based local database with `DatabaseService` and `AuthService`
- initialise Hive in `main.dart`
- document local storage and DB usage
- add required dependencies

## Testing
- `flutter test` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_685428f050d0832b84d7a2e9db71f00f