### PR TITLE
Use SQLite data for dashboard and donation records

### DIFF
--- a/lib/core/app_export.dart
+++ b/lib/core/app_export.dart
@@ -10,4 +10,5 @@ export 'package:noor_funds/core/services/local_storage_service.dart';
 export 'package:noor_funds/core/services/database_service.dart';
 export 'package:noor_funds/core/services/auth_service.dart';
 export 'package:noor_funds/core/services/sqlite_service.dart';
+export 'package:noor_funds/core/services/donation_service.dart';
 

--- a/lib/core/services/auth_service.dart
+++ b/lib/core/services/auth_service.dart
@@ -38,4 +38,13 @@ class AuthService {
     };
 
   }
+
+  /// Returns the currently logged in user based on stored credentials.
+  static Future<Map<String, dynamic>?> getCurrentUser() async {
+    final creds = getCredentials();
+    if (creds['email'] != null && creds['password'] != null) {
+      return await SqliteService.getUser(creds['email']!, creds['password']!);
+    }
+    return null;
+  }
 }

--- a/lib/core/services/donation_service.dart
+++ b/lib/core/services/donation_service.dart
@@ -1,0 +1,27 @@
+import 'sqlite_service.dart';
+import 'auth_service.dart';
+
+class DonationService {
+  static Future<int> addDonation(Map<String, dynamic> donation) async {
+    final user = await AuthService.getCurrentUser();
+    if (user == null) {
+      throw Exception('No logged in user');
+    }
+    final data = Map<String, dynamic>.from(donation);
+    data['user_id'] = user['id'];
+    return await SqliteService.addDonation(data);
+  }
+
+  static Future<List<Map<String, dynamic>>> getUserDonations() async {
+    final user = await AuthService.getCurrentUser();
+    if (user == null) {
+      return [];
+    }
+    final rows = await SqliteService.getUserDonations(user['id'] as int);
+    return rows;
+  }
+
+  static Future<void> deleteDonation(int id) async {
+    await SqliteService.deleteDonation(id);
+  }
+}

--- a/lib/core/services/sqlite_service.dart
+++ b/lib/core/services/sqlite_service.dart
@@ -4,7 +4,7 @@ import 'package:sqflite/sqflite.dart';
 class SqliteService {
   static Database? _db;
   static const _dbName = 'noor_funds.db';
-  static const _dbVersion = 1;
+  static const _dbVersion = 2;
 
   static Future<void> init() async {
     final dbPath = await getDatabasesPath();
@@ -13,6 +13,7 @@ class SqliteService {
       path,
       version: _dbVersion,
       onCreate: _onCreate,
+      onUpgrade: _onUpgrade,
     );
   }
 
@@ -30,11 +31,23 @@ class SqliteService {
         user_id INTEGER NOT NULL,
         donor_name TEXT,
         amount REAL,
+        currency TEXT,
         date TEXT,
+        category TEXT,
         notes TEXT,
+        image_path TEXT,
         FOREIGN KEY(user_id) REFERENCES users(id) ON DELETE CASCADE
       )
     ''');
+  }
+
+  static Future<void> _onUpgrade(
+      Database db, int oldVersion, int newVersion) async {
+    if (oldVersion < 2) {
+      await db.execute("ALTER TABLE donations ADD COLUMN currency TEXT");
+      await db.execute("ALTER TABLE donations ADD COLUMN category TEXT");
+      await db.execute("ALTER TABLE donations ADD COLUMN image_path TEXT");
+    }
   }
 
   static Database get _database => _db!;
@@ -61,6 +74,10 @@ class SqliteService {
 
   static Future<int> addDonation(Map<String, dynamic> donation) async {
     return await _database.insert('donations', donation);
+  }
+
+  static Future<int> deleteDonation(int id) async {
+    return await _database.delete('donations', where: 'id = ?', whereArgs: [id]);
   }
 
   static Future<List<Map<String, dynamic>>> getUserDonations(int userId) async {

--- a/lib/presentation/dashboard_home/dashboard_home.dart
+++ b/lib/presentation/dashboard_home/dashboard_home.dart
@@ -21,64 +21,37 @@ class _DashboardHomeState extends State<DashboardHome>
   String _selectedCurrency = 'SAR';
   late TabController _tabController;
 
-  // Mock data for donations
-  final List<Map<String, dynamic>> _donationData = [
-    {
-      "id": 1,
-      "donorName": "Ahmed Al-Rashid",
-      "amount": 500.0,
-      "currency": "SAR",
-      "date": DateTime.now().subtract(Duration(days: 1)),
-      "category": "Zakat",
-    },
-    {
-      "id": 2,
-      "donorName": "Fatima Hassan",
-      "amount": 250.0,
-      "currency": "SAR",
-      "date": DateTime.now().subtract(Duration(days: 2)),
-      "category": "Sadaqah",
-    },
-    {
-      "id": 3,
-      "donorName": "Omar Abdullah",
-      "amount": 1000.0,
-      "currency": "SAR",
-      "date": DateTime.now().subtract(Duration(days: 3)),
-      "category": "Zakat",
-    },
-    {
-      "id": 4,
-      "donorName": "Aisha Mohamed",
-      "amount": 150.0,
-      "currency": "SAR",
-      "date": DateTime.now().subtract(Duration(days: 5)),
-      "category": "Sadaqah",
-    },
-    {
-      "id": 5,
-      "donorName": "Khalid Ibrahim",
-      "amount": 750.0,
-      "currency": "SAR",
-      "date": DateTime.now().subtract(Duration(days: 7)),
-      "category": "Zakat",
-    },
-  ];
-
-  final List<Map<String, dynamic>> _chartData = [
-    {"day": "Day 1", "amount": 500.0},
-    {"day": "Day 2", "amount": 750.0},
-    {"day": "Day 3", "amount": 1000.0},
-    {"day": "Day 4", "amount": 300.0},
-    {"day": "Day 5", "amount": 850.0},
-    {"day": "Day 6", "amount": 600.0},
-    {"day": "Day 7", "amount": 950.0},
-  ];
+  List<Map<String, dynamic>> _donationData = [];
+  List<Map<String, dynamic>> _chartData = [];
 
   @override
   void initState() {
     super.initState();
     _tabController = TabController(length: 5, vsync: this);
+    _loadDonations();
+  }
+
+  Future<void> _loadDonations() async {
+    final data = await DonationService.getUserDonations();
+    setState(() {
+      _donationData = data
+          .map((d) => {
+                'id': d['id'],
+                'donorName': d['donor_name'],
+                'amount': d['amount'],
+                'currency': d['currency'] ?? 'SAR',
+                'date': DateTime.tryParse(d['date'] ?? '') ?? DateTime.now(),
+                'category': d['category'] ?? 'General',
+              })
+          .toList();
+
+      _chartData = _donationData
+          .map((e) => {
+                'day': e['date'].toString().split('T').first,
+                'amount': e['amount'],
+              })
+          .toList();
+    });
   }
 
   @override
@@ -125,8 +98,7 @@ class _DashboardHomeState extends State<DashboardHome>
   }
 
   Future<void> _refreshData() async {
-    await Future.delayed(Duration(seconds: 1));
-    setState(() {});
+    await _loadDonations();
   }
 
   void _onTabTapped(int index) {

--- a/lib/presentation/donation_record_detail/donation_record_detail.dart
+++ b/lib/presentation/donation_record_detail/donation_record_detail.dart
@@ -21,38 +21,21 @@ class _DonationRecordDetailState extends State<DonationRecordDetail> {
   late TextEditingController notesController;
   late TextEditingController receiptNumberController;
 
-  // Mock donation data
-  final Map<String, dynamic> donationData = {
-    "id": "DON-2024-001",
-    "donorName": "أحمد محمد الخالدي",
-    "donorNameEn": "Ahmed Mohammed Al-Khalidi",
-    "amount": 500.0,
-    "currency": "SAR",
-    "date": "2024-01-15",
-    "hijriDate": "1445-07-04",
-    "category": "زكاة",
-    "categoryEn": "Zakat",
-    "receiptNumber": "RCP-2024-001",
-    "notes": "تبرع شهري منتظم للمسجد",
-    "notesEn": "Regular monthly donation for mosque",
-    "documentImage":
-        "https://images.pexels.com/photos/6801648/pexels-photo-6801648.jpeg?auto=compress&cs=tinysrgb&w=1260&h=750&dpr=1",
-    "createdAt": "2024-01-15T10:30:00Z",
-    "lastModified": "2024-01-15T10:30:00Z",
-    "organizationName": "مسجد النور الإسلامي",
-    "organizationNameEn": "Al-Noor Islamic Mosque"
-  };
+  late Map<String, dynamic> donationData;
 
   @override
   void initState() {
     super.initState();
-    donorNameController =
-        TextEditingController(text: donationData["donorNameEn"]);
-    amountController =
-        TextEditingController(text: donationData["amount"].toString());
-    notesController = TextEditingController(text: donationData["notesEn"]);
-    receiptNumberController =
-        TextEditingController(text: donationData["receiptNumber"]);
+  }
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    donationData = ModalRoute.of(context)?.settings.arguments as Map<String, dynamic>? ?? {};
+    donorNameController = TextEditingController(text: donationData['donorName'] ?? '');
+    amountController = TextEditingController(text: donationData['amount']?.toString() ?? '');
+    notesController = TextEditingController(text: donationData['notes'] ?? '');
+    receiptNumberController = TextEditingController(text: donationData['receiptNumber'] ?? '');
   }
 
   @override
@@ -109,7 +92,7 @@ class _DonationRecordDetailState extends State<DonationRecordDetail> {
             children: [
               Text('Are you sure you want to delete this donation record?'),
               SizedBox(height: 16),
-              Text('Donor: ${donationData["donorNameEn"]}'),
+              Text('Donor: ${donationData["donorName"] ?? ''}'),
               Text(
                   'Amount: ${donationData["currency"]} ${donationData["amount"]}'),
               Text('Date: ${donationData["date"]}'),
@@ -345,9 +328,10 @@ class _DonationRecordDetailState extends State<DonationRecordDetail> {
             crossAxisAlignment: CrossAxisAlignment.start,
             children: [
               // Document Image
-              DocumentImageWidget(
-                imageUrl: donationData["documentImage"],
-              ),
+              if (donationData["documentImage"] != null)
+                DocumentImageWidget(
+                  imageUrl: donationData["documentImage"],
+                ),
 
               SizedBox(height: 24),
 

--- a/lib/presentation/donation_records_list/donation_records_list.dart
+++ b/lib/presentation/donation_records_list/donation_records_list.dart
@@ -31,7 +31,7 @@ class _DonationRecordsListState extends State<DonationRecordsList>
   void initState() {
     super.initState();
     _tabController = TabController(length: 4, vsync: this, initialIndex: 1);
-    _loadMockData();
+    _loadData();
     _scrollController.addListener(_onScroll);
   }
 
@@ -43,76 +43,26 @@ class _DonationRecordsListState extends State<DonationRecordsList>
     super.dispose();
   }
 
-  void _loadMockData() {
-    _allRecords = [
-      {
-        "id": 1,
-        "donorName": "أحمد محمد علي",
-        "donorNameEn": "Ahmed Mohammed Ali",
-        "amount": 500.0,
-        "currency": "SAR",
-        "date": DateTime.now().subtract(Duration(days: 1)),
-        "category": "Zakat",
-        "categoryAr": "زكاة",
-        "notes": "Monthly zakat payment",
-        "receiptNumber": "ZK001",
-        "paymentMethod": "Cash"
-      },
-      {
-        "id": 2,
-        "donorName": "فاطمة أحمد",
-        "donorNameEn": "Fatima Ahmed",
-        "amount": 250.0,
-        "currency": "SAR",
-        "date": DateTime.now().subtract(Duration(days: 3)),
-        "category": "Sadaqah",
-        "categoryAr": "صدقة",
-        "notes": "General donation",
-        "receiptNumber": "SD002",
-        "paymentMethod": "Bank Transfer"
-      },
-      {
-        "id": 3,
-        "donorName": "محمد عبدالله",
-        "donorNameEn": "Mohammed Abdullah",
-        "amount": 1000.0,
-        "currency": "SAR",
-        "date": DateTime.now().subtract(Duration(days: 5)),
-        "category": "Mosque Fund",
-        "categoryAr": "صندوق المسجد",
-        "notes": "Mosque renovation fund",
-        "receiptNumber": "MF003",
-        "paymentMethod": "Cash"
-      },
-      {
-        "id": 4,
-        "donorName": "عائشة سالم",
-        "donorNameEn": "Aisha Salem",
-        "amount": 150.0,
-        "currency": "SAR",
-        "date": DateTime.now().subtract(Duration(days: 7)),
-        "category": "Orphan Support",
-        "categoryAr": "دعم الأيتام",
-        "notes": "Monthly orphan support",
-        "receiptNumber": "OS004",
-        "paymentMethod": "Credit Card"
-      },
-      {
-        "id": 5,
-        "donorName": "يوسف إبراهيم",
-        "donorNameEn": "Yusuf Ibrahim",
-        "amount": 750.0,
-        "currency": "SAR",
-        "date": DateTime.now().subtract(Duration(days: 10)),
-        "category": "Education Fund",
-        "categoryAr": "صندوق التعليم",
-        "notes": "Islamic education support",
-        "receiptNumber": "EF005",
-        "paymentMethod": "Bank Transfer"
-      },
-    ];
+  Future<void> _loadData() async {
+    final data = await DonationService.getUserDonations();
+    _allRecords = data
+        .map((d) => {
+              'id': d['id'],
+              'donorName': d['donor_name'],
+              'donorNameEn': d['donor_name'],
+              'amount': d['amount'],
+              'currency': d['currency'] ?? 'SAR',
+              'date': DateTime.tryParse(d['date'] ?? '') ?? DateTime.now(),
+              'category': d['category'] ?? 'General',
+              'categoryAr': d['category'] ?? 'General',
+              'notes': d['notes'] ?? '',
+              'receiptNumber': d['receipt_number'] ?? '',
+              'paymentMethod': d['payment_method'] ?? '',
+            })
+        .toList();
     _filteredRecords = List.from(_allRecords);
     _sortRecords();
+    setState(() {});
   }
 
   void _onScroll() {
@@ -145,8 +95,7 @@ class _DonationRecordsListState extends State<DonationRecordsList>
 
     HapticFeedback.lightImpact();
 
-    // Simulate refresh
-    await Future.delayed(Duration(seconds: 1));
+    await _loadData();
 
     if (mounted) {
       setState(() {
@@ -262,11 +211,10 @@ class _DonationRecordsListState extends State<DonationRecordsList>
                       child: Text('Cancel')),
                   TextButton(
                       onPressed: () {
+                        DonationService.deleteDonation(record['id']);
                         setState(() {
-                          _allRecords
-                              .removeWhere((r) => r['id'] == record['id']);
-                          _filteredRecords
-                              .removeWhere((r) => r['id'] == record['id']);
+                          _allRecords.removeWhere((r) => r['id'] == record['id']);
+                          _filteredRecords.removeWhere((r) => r['id'] == record['id']);
                         });
                         Navigator.pop(context);
                         HapticFeedback.heavyImpact();

--- a/lib/presentation/ocr_camera_scan/ocr_camera_scan.dart
+++ b/lib/presentation/ocr_camera_scan/ocr_camera_scan.dart
@@ -165,7 +165,8 @@ class _OcrCameraScanState extends State<OcrCameraScan>
       final path = await LocalStorageService.saveImage(File(_capturedImage!.path));
       donationData['imagePath'] = path;
     }
-    await DatabaseService.donationsBox.add(donationData);
+    donationData['amount'] = double.tryParse(donationData['amount'] ?? '0') ?? 0;
+    await DonationService.addDonation(donationData);
     Navigator.of(context).pop(); // Close bottom sheet
     Navigator.of(context).pop(); // Return to previous screen
 


### PR DESCRIPTION
## Summary
- fetch donations for the logged-in user using a new `DonationService`
- update SQLite schema for currency, category and image path
- load dashboard and records list from the database
- save scanned donations to SQLite
- support dynamic donation details screen

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685b056390ec832ba034c99a1220dbf2